### PR TITLE
Update node version to 14 

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.18.2 as build
+FROM node:14 as build
 
 ARG REACT_APP_SERVICES_HOST=/services/m
 


### PR DESCRIPTION
docker compose fails to finish with node version 12.18.2  as @testing-library/dom@9.3.1 will throw an error expecting a version >=14.

Will need to update the blog to reflect this as well:
https://www.docker.com/blog/how-to-use-the-official-nginx-docker-image/

Also...
`docker-compose up` was not a valid command for me, I used `docker compose up` instead.